### PR TITLE
ckeditor-math: ckeditor @ v25.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ckeditor5-math",
-  "version": "25.0.0",
+  "name": "@peergrade/ckeditor5-math",
+  "version": "25.0.0-next.0",
   "description": "Math feature for CKEditor 5.",
   "keywords": [
     "ckeditor",


### PR DESCRIPTION
Upstream PR: https://github.com/isaul32/ckeditor5-math/pull/26

Updated via `ncu '/.*@ckeditor.*/' -u` ([more on ncu](https://www.npmjs.com/package/npm-check-updates))